### PR TITLE
Add React Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 | Shadcn UI Templates | A collection of Free & Premium templates and resources for shadcn/ui. | https://shadcnui-templates.com |
 | horizon-ai-nextjs-shadcn-boilerplate | Premium AI NextJS & shadcn/ui Boilerplate + Stripe + Supabase + OAuth | https://horizon-ui.com/boilerplate-shadcn |
 | template-next | A clean Next.js template with TypeScript,TailwindCSS,Shadcn/ui,and Prettier. | https://template-next-official.vercel.app/ |
+| React Starter Kit | A full-stack boilerplate for building modern web applications with Bun, TypeScript, React, tRPC, Drizzle ORM, and Cloudflare Workers. | https://github.com/kriasoft/react-starter-kit |
 
 ## Components
 | Name | Description | Link |


### PR DESCRIPTION
React Starter Kit is a boilerplate for building modern full-stack web applications with Bun, TypeScript, React, tRPC, and Drizzle ORM. It is designed to be a starting point for developers who want to create modern web applications with a focus on performance, simplicity, and best practices, with out-of-the-box support for edge-native deployment on Cloudflare Workers.

Repository: https://github.com/kriasoft/react-starter-kit
License: MIT