### PR TITLE
Add Shadcnblocks to UI libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 | Lukacho UI | Next Generation UI Components. | https://ui.lukacho.com/components |
 | Myna UI | TailwindCSS and shadcn/ui UI Kit for Figma and React. | https://mynaui.com/ |
 | shadcn/studio | Accelerate your project development with ready-to-use, and fully customizable shadcn ui Components, Blocks, UI Kits, Boilerplates, Templates and Themes with AI Tools | https://shadcnstudio.com/ |
+| Shadcnblocks | Premium shadcn/ui blocks, component variants, templates, themes, and admin dashboard patterns for React, Next.js, Astro, and Tailwind CSS. | https://www.shadcnblocks.com/ |
 | Manifest UI | Component library for ChatGPT Apps and MCP Apps | https://ui.manifest.build |
 | RENBLOX | Reusable React and Next.js blocks built on shadcn/ui, with a visual page builder. | https://renblox.com |
 


### PR DESCRIPTION
## Summary

- Add Shadcnblocks to the UI Libs section as a shadcn/ui blocks, components, templates, themes, and admin dashboard resource.

## Notes

Shadcnblocks is a shadcn/ui-focused library for React, Next.js, Astro, and Tailwind CSS projects.