### PR TITLE
Add 21st.dev Agent Elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 | shadcn/studio | Accelerate your project development with ready-to-use, and fully customizable shadcn ui Components, Blocks, UI Kits, Boilerplates, Templates and Themes with AI Tools | https://shadcnstudio.com/ |
 | Manifest UI | Component library for ChatGPT Apps and MCP Apps | https://ui.manifest.build |
 | RENBLOX | Reusable React and Next.js blocks built on shadcn/ui, with a visual page builder. | https://renblox.com |
+| 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |
 
 ## Templates
 | Name | Description | Link |


### PR DESCRIPTION
Adds **[21st.dev Agent Elements](https://agent-elements.21st.dev)** to the UI Libs section.

Open-source shadcn registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan, MCP, Thinking, Subagent), clarifying questions, composable input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK.

Install:
```
npx shadcn@latest add https://agent-elements.21st.dev/r/agent-chat.json
```

- Site: https://agent-elements.21st.dev
- Repo: https://github.com/21st-dev/agent-elements
- Registry: https://agent-elements.21st.dev/r/index.json
- License: MIT