### PR TITLE
Add Loading UI (loading-ui.com) — curated loaders for shadcn-style apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 ## UI Libs
 | Name | Description | Link |
 |------|-------------|------|
+| Loading UI | A curated, free, open-source collection of spinners, loaders, and loading-state animations for modern web apps. | https://loading-ui.com/ |
 | Aceternity UI | Copy paste the most trending components and use them in your websites without having to worry about styling and animations. | https://ui.aceternity.com/ |
 | Magic UI | UI Library for Design Engineers. Animated components and effects you can copy and paste into your apps. | https://github.com/magicuidesign/magicui |
 | Magic UI Pro | 50+ beautiful sections and templates built with React, Typescript, Tailwind CSS, and Framer Motion. | https://pro.magicui.design/?ref=bytefer |


### PR DESCRIPTION
## Summary

Adds [Loading UI](https://loading-ui.com/) as the entry under **UI Libs**

## Why include it?

- **Focus**: Spinners, loaders, skeletons, and "thinking"/async text treatments—frequent gaps when people adopt shadcn/ui for dashboards and AI surfaces.
- **How it helps users**: One place to compare live variants (rings, dots, text shimmer, terminal-style boot, image-analysis placeholder, etc.), then copy code instead of pasting from random demos.
- **Fit for this list**: Aligned with copy-paste, Tailwind-first workflows the awesome list already highlights; [loading-ui.com](https://loading-ui.com/) is free, open source, and built with [TurboStarter](https://turbostarter.dev/).