### PR TITLE
Add Memoire to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@
 | Fluid Tailwind | Build better responsive designs in less code. | https://github.com/barvian/fluid-tailwind |
 | Opensearch AI | SearchGPT / Perplexity clone,but personalised for you. | https://github.com/supermemoryai/opensearch-ai |
 | Shadcn Chat | CLI for adding customizable and re-usable chat components to your applications. | https://github.com/jakobhoeg/shadcn-chat |
+| Memoire | MCP server and CLI for shadcn-native Design CI. Diagnose UI debt, extract Tailwind tokens, export shadcn registries, and plan safe UI fixes. | https://github.com/sarveshsea/m-moire |
 | Memfree | Open Source Hybrid AI Search Engine,Instantly Get Accurate Answers from the Internet,Bookmarks,Notes,and Docs. Support One-Click Deployment. It built using Next.js,Typescript,and shadcn/ui. | https://github.com/memfreeme/memfree |
 | Shadcn Form Builder | Create forms with Shadcn,react-hooks-form and zod within minutes | https://github.com/hasanharman/form-builder |
 | Invoify | An invoice generator app built using Next.js,Typescript,and shadcn/ui | https://github.com/aliabb01/invoify |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@
 | Fluid Tailwind | Build better responsive designs in less code. | https://github.com/barvian/fluid-tailwind |
 | Opensearch AI | SearchGPT / Perplexity clone,but personalised for you. | https://github.com/supermemoryai/opensearch-ai |
 | Shadcn Chat | CLI for adding customizable and re-usable chat components to your applications. | https://github.com/jakobhoeg/shadcn-chat |
-| Memoire | MCP server and CLI for shadcn-native Design CI. Diagnose UI debt, extract Tailwind tokens, export shadcn registries, and plan safe UI fixes. | https://github.com/sarveshsea/m-moire |
+| Memi | Agent design CI for shadcn/ui and Tailwind with focused Agent Skills, UI audits, token extraction, component scaffolds, accessibility checks, and quality gates. | https://github.com/sarveshsea/memi |
 | Memfree | Open Source Hybrid AI Search Engine,Instantly Get Accurate Answers from the Internet,Bookmarks,Notes,and Docs. Support One-Click Deployment. It built using Next.js,Typescript,and shadcn/ui. | https://github.com/memfreeme/memfree |
 | Shadcn Form Builder | Create forms with Shadcn,react-hooks-form and zod within minutes | https://github.com/hasanharman/form-builder |
 | Invoify | An invoice generator app built using Next.js,Typescript,and shadcn/ui | https://github.com/aliabb01/invoify |


### PR DESCRIPTION
## Summary\n\nAdds Memoire to the Tools section. Memoire is relevant to shadcn/ui users because it audits existing Tailwind/shadcn apps, extracts tokens, exports shadcn-compatible registries, and exposes the workflow through MCP for AI editors.\n\n## Link\n\nhttps://github.com/sarveshsea/m-moire