### PR TITLE
docs(feat): add Payload Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | Myna UI | TailwindCSS and shadcn/ui UI Kit for Figma and React. | https://mynaui.com/ |
 | shadcn/studio | Accelerate your project development with ready-to-use, and fully customizable shadcn ui Components, Blocks, UI Kits, Boilerplates, Templates and Themes with AI Tools | https://shadcnstudio.com/ |
 | Shadcnblocks | Premium shadcn/ui blocks, component variants, templates, themes, and admin dashboard patterns for React, Next.js, Astro, and Tailwind CSS. | https://www.shadcnblocks.com/ |
+| Payload Components | MIT shadcn-compatible registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects. | https://www.payload-components.xyz/ |
 | Manifest UI | Component library for ChatGPT Apps and MCP Apps | https://ui.manifest.build |
 | RENBLOX | Reusable React and Next.js blocks built on shadcn/ui, with a visual page builder. | https://renblox.com |
 | 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |


### PR DESCRIPTION
Adds Payload Components to the UI Libs table.

Payload Components is an MIT shadcn-compatible registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects.

Validation:
- `git diff --check`
