### PR TITLE
docs: add Dominik UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | RENBLOX | Reusable React and Next.js blocks built on shadcn/ui, with a visual page builder. | https://renblox.com |
 | 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |
 | Trophy UI | Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS. | https://ui.trophy.so |
-| Dominik UI | An open-source shadcn/ui registry of animated React components: expandable icon tabs and a multi-variant braille loading indicator. | https://dominikkoch.dev/registry |
+| Dominik UI | Opinionated components and tools for building modern AI interfaces. | https://dominikkoch.dev/ui |
 
 ## Templates
 | Name | Description | Link |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | RENBLOX | Reusable React and Next.js blocks built on shadcn/ui, with a visual page builder. | https://renblox.com |
 | 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |
 | Trophy UI | Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS. | https://ui.trophy.so |
+| Dominik UI | An open-source shadcn/ui registry of animated React components: expandable icon tabs and a multi-variant braille loading indicator. | https://dominikkoch.dev/registry |
 
 ## Templates
 | Name | Description | Link |


### PR DESCRIPTION
Adds Dominik UI to the UI Libs section.

Homepage: https://dominikkoch.dev/registry
GitHub: https://github.com/mezotv/portfolio

An open-source shadcn/ui registry of animated React components: expandable icon tabs with a sliding active pill and a multi-variant braille loading indicator. Already listed in the official shadcn-ui/ui registry directory.