### PR TITLE
Add LocalMode to UI Libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |
 | Trophy UI | Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS. | https://ui.trophy.so |
 | UIAble | UIAble is built on top of shadcn/ui with a vivid design system, production-ready open-source React components, and complete code ownership. | https://github.com/codedthemes/uiable |
+| LocalMode | Local-first AI UI registry with 107 copy-owned primitives and 36 composed blocks (chat, RAG, Whisper transcription, CLIP image search) that run entirely in the browser, no servers or API keys. | https://localmode.ai |
 
 ## Templates
 | Name | Description | Link |


### PR DESCRIPTION
This PR adds **LocalMode** to the **UI Libs** section.

LocalMode is a local-first AI UI registry: 107 copy-owned primitives and 36 composed blocks (chat, RAG, Whisper transcription, CLIP image search) that run entirely in the browser, installed via the shadcn CLI. Open source (MIT), with no servers and no API keys.

Repository: https://github.com/LocalMode-AI/LocalMode
Registry and live demos: https://localmode.ai
