### PR TITLE
Add Payload Components to shadcn UI libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | Trophy UI | Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS. | https://ui.trophy.so |
 | UIAble | UIAble is built on top of shadcn/ui with a vivid design system, production-ready open-source React components, and complete code ownership. | https://github.com/codedthemes/uiable |
 
+| Payload Components | 67 MIT typed Payload CMS blocks for Payload v3 + Next.js 15/16; installed as owned source with automated Pages, renderer, types, and admin import-map wiring. | https://www.payload-components.xyz/ |
+
 ## Templates
 | Name | Description | Link |
 |------|-------------|------|


### PR DESCRIPTION
awesome-shadcn-ui's UI Libs table highlights source-oriented shadcn collections that accelerate component delivery.

[Payload Components](https://www.payload-components.xyz) extends that benefit to Payload v3 + Next.js 15/16: 67 MIT typed blocks install as owned source, and the CLI automates Pages, renderer, generated-types, and admin import-map wiring. The audience gets shadcn-style control plus a complete CMS integration path.

The proposed row matches the existing Name, Description, and Link schema exactly.