### PR TITLE
Add MailKite SaaS Starter to Saas table

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | SaasHQ | Saas CRM/ERP Starter Kit for Nextjs Prisma and Postgres. An excellent resource for buildnig things in Nextjs. | https://github.com/saashqdev/saashq |
 | Convex SaaS | A production-ready Convex Stack for your next SaaS application with Convex Auth, Stripe, TanStack, Resend, Tailwindcss, and shadcn. | https://github.com/get-convex/convex-saas |
 | Next Money Stripe Starter | Empower your next project with the stack of Next.js 14, Prisma, Supabase, Clerk Auth, Resend, React Email, Shadcn/ui, and Stripe. | https://github.com/virgoone/next-money |
+| MailKite SaaS Starter | Production-ready Next.js 15 SaaS starter: self-contained auth (Google/GitHub OAuth + email/password, no auth vendor), Stripe subscriptions, teams, Postgres/Drizzle, dark-first shadcn/ui. | https://github.com/mailkite/saas-startup |
 
 ## UI Libs
 | Name | Description | Link |


### PR DESCRIPTION
Hi 👋

Adding **MailKite SaaS Starter** to the `## Saas` table (appended at the end, matching the 3-column `| Name | Description | Link |` format).

**What it is:** a production-ready Next.js 15 SaaS starter with self-contained auth (Google/GitHub OAuth + email/password — **no Clerk/Auth0/Supabase account needed**), Stripe subscriptions, teams, Postgres + Drizzle, and a dark-first shadcn/ui dashboard. It's built around shadcn/ui end-to-end (landing page, dashboard, auth), so it fits this list naturally.

- Repo: https://github.com/mailkite/saas-startup — MIT, actively maintained
- Live demo: https://saas-startup.mailkite.dev

Most SaaS starters in this table wire in a hosted auth provider; this one runs auth in your own app, which is a meaningfully different starting point. Happy to adjust the wording — thanks for curating the list!
