### PR TITLE
Add UI Beats to UI Libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |
 | Trophy UI | Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS. | https://ui.trophy.so |
 | UIAble | UIAble is built on top of shadcn/ui with a vivid design system, production-ready open-source React components, and complete code ownership. | https://github.com/codedthemes/uiable |
+| UI Beats | Animated React components built with TypeScript, Tailwind CSS and Motion. Copy, paste, or install with the shadcn CLI. | https://github.com/nikhils4/ui-beats |
 
 ## Templates
 | Name | Description | Link |


### PR DESCRIPTION
Adds [UI Beats](https://github.com/nikhils4/ui-beats) to the **UI Libs** table, appended at the bottom in keeping with the existing ordering.

UI Beats is a free, MIT-licensed shadcn-compatible registry of animated React components built with TypeScript, Tailwind CSS and Motion. Components install through the shadcn CLI, so the source is written into your project.

- Site: https://uibeats.com
- Registry: https://uibeats.com/r/registry.json

Not currently listed — checked before opening.
