### PR TITLE
Add crafterui to UI Libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |
 | Trophy UI | Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS. | https://ui.trophy.so |
 | UIAble | UIAble is built on top of shadcn/ui with a vivid design system, production-ready open-source React components, and complete code ownership. | https://github.com/codedthemes/uiable |
+| crafterui | Open-source motion and interaction components for React and Tailwind: 3D carousels, scroll letter reveals, a Dynamic Island, cursor hit-testing and rolling countdowns. Installed with the shadcn CLI and copied into your project as source. | https://crafterui.com |
 
 ## Templates
 | Name | Description | Link |


### PR DESCRIPTION
crafterui is an open-source registry of motion and interaction components for React and Tailwind: 3D carousels, scroll letter reveals, a Dynamic Island, cursor hit-testing and rolling countdowns. Every component installs with the shadcn CLI and is copied into your project as source, so nothing is added to your runtime dependencies. MIT licensed, with a live demo and full source for each component.

```bash
npx shadcn@latest add https://crafterui.com/r/letter-reveal.json
```

https://crafterui.com — https://github.com/SriSomanaath/crafterui