### PR TITLE
Add AI Canvas to UI Libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Find the best open-source alternatives to popular software - <a href='https://ww
 | 21st.dev Agent Elements | Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK. | https://agent-elements.21st.dev |
 | Trophy UI | Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS. | https://ui.trophy.so |
 | UIAble | UIAble is built on top of shadcn/ui with a vivid design system, production-ready open-source React components, and complete code ownership. | https://github.com/codedthemes/uiable |
+| AI Canvas | Animated React components and UI blocks built with TypeScript, Tailwind CSS and Framer Motion. Free library is MIT and installs through the shadcn CLI; many components ship with an AI remix prompt. | https://aicanvas.me |
 
 ## Templates
 | Name | Description | Link |


### PR DESCRIPTION
Adds AI Canvas to the UI Libs table.

AI Canvas is a registry of animated React components and UI blocks built with TypeScript, Tailwind CSS v4 and Framer Motion. The free library is MIT licensed with full source in the public repo, it is listed in the official shadcn registry directory, and components install through the shadcn CLI.

- Site: https://aicanvas.me
- Source: https://github.com/uiNerd16/aicanvas

Checked the README first, there was no existing entry.